### PR TITLE
修复 Arch Linux 证书无法正确安装导致无法使用的问题

### DIFF
--- a/pkg/certificate/certificate_linux.go
+++ b/pkg/certificate/certificate_linux.go
@@ -10,11 +10,49 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
+
+// 检查是否以 root 权限运行
+func isRoot() bool {
+	return os.Geteuid() == 0
+}
+
+// 确保 root 权限，如果没有则自动请求 sudo
+func ensureRoot(commandName string) bool {
+	if !isRoot() {
+		execPath, err := os.Executable()
+		if err != nil {
+			return false
+		}
+		fmt.Println("需要管理员权限，正在请求...")
+		cmd := exec.Command("sudo", execPath, commandName)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return false
+		}
+		os.Exit(0)
+	}
+	return true
+}
+
+// 执行 certutil 命令
+func runCertutilQuiet(args ...string) error {
+	cmd := exec.Command("certutil", args...)
+	// certutil --empty-password 仍然需要 stdin 输入（按两次 Enter）
+	cmd.Stdin = strings.NewReader("\n\n")
+	return cmd.Run()
+}
 
 func fetchCertificates() ([]Certificate, error) {
 	var certs []Certificate
-	paths := []string{"/etc/ssl/certs", "/usr/local/share/ca-certificates"}
+	paths := []string{
+		"/etc/ssl/certs",
+		"/usr/local/share/ca-certificates",
+		"/etc/ca-certificates/trust-source/anchors", // Arch Linux
+	}
 
 	for _, dir := range paths {
 		_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
@@ -53,39 +91,131 @@ func fetchCertificates() ([]Certificate, error) {
 }
 
 func installCertificate(cert []byte) error {
-	certPath := "/usr/local/share/ca-certificates/WeChatAppEx_CA.crt"
-	err := os.WriteFile(certPath, cert, 0644)
-	if err != nil {
+	// 检查 root 权限
+	if !ensureRoot("install") {
+		return fmt.Errorf("需要 root 权限安装证书")
+	}
+
+	var certPath string
+	var updateCmd []string
+	var updateErrMsg string
+
+	// 简单检测发行版类型
+	if _, err := exec.LookPath("update-ca-certificates"); err == nil {
+		// Ubuntu/Debian 系
+		certPath = "/usr/local/share/ca-certificates/WeChatAppEx_CA.crt"
+		updateCmd = []string{"update-ca-certificates", "--fresh"}
+		updateErrMsg = "更新 OpenSSL 证书库失败"
+	} else if _, err := exec.LookPath("trust"); err == nil {
+		// Arch Linux 系
+		certPath = "/etc/ca-certificates/trust-source/anchors/WeChatAppEx_CA.crt"
+		updateCmd = []string{"trust", "extract-compat"}
+		updateErrMsg = "更新证书库失败 (trust)"
+	} else {
+		return fmt.Errorf("未找到支持的证书更新命令！ (update-ca-certificates 或 trust)")
+	}
+
+	// 创建证书目录
+	if err := os.MkdirAll(filepath.Dir(certPath), 0755); err != nil {
+		return fmt.Errorf("创建证书目录失败: %v", err)
+	}
+
+	// 写入证书文件
+	if err := os.WriteFile(certPath, cert, 0644); err != nil {
 		return fmt.Errorf("写入证书失败: %v", err)
 	}
-	if output, err := exec.Command("update-ca-certificates", "--fresh").CombinedOutput(); err != nil {
-		return fmt.Errorf("更新 OpenSSL 证书库失败: %v\n输出: %s", err, string(output))
+
+	// 更新证书库
+	if output, err := exec.Command(updateCmd[0], updateCmd[1:]...).CombinedOutput(); err != nil {
+		return fmt.Errorf("%s: %v\n输出: %s", updateErrMsg, err, string(output))
 	}
+
+	// NSS 证书库处理 (Firefox/Chromium)
 	if _, err := exec.LookPath("certutil"); err == nil {
-		exec.Command("certutil", "-d", "sql:/etc/pki/nssdb", "-D", "-n", "WeChatAppEx_CA").Run()
-		exec.Command("certutil", "-d", "sql:/etc/pki/nssdb", "-A", "-n", "WeChatAppEx_CA", "-t", "CT,C,C", "-i", certPath).Run()
-		if home, _ := os.UserHomeDir(); home != "" {
+		// 系统 NSS 数据库
+		systemDB := "/etc/pki/nssdb"
+		if _, err := os.Stat(systemDB); os.IsNotExist(err) {
+			// Arch Linux 默认没有 NSS 数据库，但是是必要的。需要创建
+			fmt.Printf("未找到 NSS 系统数据库: %s，正在创建...\n", systemDB)
+			if err := os.MkdirAll(systemDB, 0700); err != nil {
+				fmt.Printf("警告: 创建 NSS 数据库目录失败: %v\n", err)
+			} else {
+				// 初始化空数据库（无密码，需要自动输入回车）
+				if err := runCertutilQuiet("-d", "sql:"+systemDB, "-N", "--empty-password"); err == nil {
+					fmt.Printf("已创建 NSS 系统数据库: %s (密码为空)\n", systemDB)
+				}
+			}
+		}
+		// 添加证书到系统 NSS 数据库
+		if _, err := os.Stat(systemDB); err == nil {
+			exec.Command("certutil", "-d", "sql:"+systemDB, "-D", "-n", "WeChatAppEx_CA").Run()
+			exec.Command("certutil", "-d", "sql:"+systemDB, "-A", "-n", "WeChatAppEx_CA", "-t", "CT,C,C", "-i", certPath).Run()
+		}
+
+		// 用户 NSS 数据库
+		if home, err := os.UserHomeDir(); err == nil && home != "" {
 			userDB := filepath.Join(home, ".pki", "nssdb")
-			os.MkdirAll(userDB, 0700)
-			userDBSQL := "sql:" + userDB
-			exec.Command("certutil", "-d", userDBSQL, "-D", "-n", "WeChatAppEx_CA").Run()
-			exec.Command("certutil", "-d", userDBSQL, "-A", "-n", "WeChatAppEx_CA", "-t", "CT,C,C", "-i", certPath).Run()
+			if _, err := os.Stat(userDB); os.IsNotExist(err) {
+				fmt.Printf("未找到 NSS 用户数据库: %s，正在创建...\n", userDB)
+				os.MkdirAll(userDB, 0700)
+				// 初始化空数据库（无密码，需要自动输入回车）
+				if err := runCertutilQuiet("-d", "sql:"+userDB, "-N", "--empty-password"); err == nil {
+					fmt.Printf("已创建 NSS 用户数据库: %s (密码为空)\n", userDB)
+				}
+			}
+			exec.Command("certutil", "-d", "sql:"+userDB, "-D", "-n", "WeChatAppEx_CA").Run()
+			exec.Command("certutil", "-d", "sql:"+userDB, "-A", "-n", "WeChatAppEx_CA", "-t", "CT,C,C", "-i", certPath).Run()
 		}
 	}
 	return nil
 }
 
 func uninstallCertificate(name string) error {
-	certPath := "/usr/local/share/ca-certificates/WeChatAppEx_CA.crt"
-	_ = os.Remove(certPath)
-	if output, err := exec.Command("update-ca-certificates", "--fresh").CombinedOutput(); err != nil {
-		return fmt.Errorf("更新 OpenSSL 证书库失败: %v\n输出: %s", err, string(output))
+	// 检查 root 权限
+	if !ensureRoot("uninstall") {
+		return fmt.Errorf("需要 root 权限卸载证书")
 	}
-	exec.Command("certutil", "-d", "sql:/etc/pki/nssdb", "-D", "-n", "WeChatAppEx_CA").Run()
-	if home, _ := os.UserHomeDir(); home != "" {
-		userDB := filepath.Join(home, ".pki", "nssdb")
-		userDBSQL := "sql:" + userDB
-		exec.Command("certutil", "-d", userDBSQL, "-D", "-n", "WeChatAppEx_CA").Run()
+
+	var certPath string
+	var updateCmd []string
+	var updateErrMsg string
+
+	// 简单检测发行版类型
+	if _, err := exec.LookPath("update-ca-certificates"); err == nil {
+		// Ubuntu/Debian 系
+		certPath = "/usr/local/share/ca-certificates/WeChatAppEx_CA.crt"
+		updateCmd = []string{"update-ca-certificates", "--fresh"}
+		updateErrMsg = "更新 OpenSSL 证书库失败"
+	} else if _, err := exec.LookPath("trust"); err == nil {
+		// Arch Linux 系
+		certPath = "/etc/ca-certificates/trust-source/anchors/WeChatAppEx_CA.crt"
+		updateCmd = []string{"trust", "extract-compat"}
+		updateErrMsg = "更新证书库失败 (trust)"
+	} else {
+		return fmt.Errorf("未找到支持的证书更新命令！ (update-ca-certificates 或 trust)")
+	}
+
+	// 删除证书文件
+	_ = os.Remove(certPath)
+
+	// 更新证书库
+	if output, err := exec.Command(updateCmd[0], updateCmd[1:]...).CombinedOutput(); err != nil {
+		return fmt.Errorf("%s: %v\n输出: %s", updateErrMsg, err, string(output))
+	}
+
+	// 从 NSS 证书库删除
+	if _, err := exec.LookPath("certutil"); err == nil {
+		// 系统 NSS 数据库
+		systemDB := "/etc/pki/nssdb"
+		if _, err := os.Stat(systemDB); err == nil {
+			exec.Command("certutil", "-d", "sql:"+systemDB, "-D", "-n", "WeChatAppEx_CA").Run()
+		}
+
+		// 用户 NSS 数据库
+		if home, err := os.UserHomeDir(); err == nil && home != "" {
+			userDB := filepath.Join(home, ".pki", "nssdb")
+			exec.Command("certutil", "-d", "sql:"+userDB, "-D", "-n", "WeChatAppEx_CA").Run()
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
在 Arch Linux 上运行程序时，证书安装失败，导致无法正常拦截 HTTPS 流量。

## 根本原因

1. **证书管理命令不同**：Arch Linux 使用 `trust` 命令管理证书，而 Ubuntu/Debian 使用 `update-ca-certificates`
2. **证书路径不同**：Arch Linux 的系统证书路径是 `/etc/ca-certificates/trust-source/anchors/`
3. **缺少 NSS 数据库**：Arch Linux 默认没有 `/etc/pki/nssdb` 目录，需要手动创建
4. **p11-kit 桥接不兼容**：虽然理论上 Arch Linux 的 NSS 通过 p11-kit 桥接了系统证书，但微信内置浏览器不支持这种机制

## 截图

### 修复前
<img width="2560" height="1600" alt="屏幕截图_20260207_140659" src="https://github.com/user-attachments/assets/b0da8822-b417-4044-82bb-0d985963c9bc" />

### 修复后
<img width="2560" height="1600" alt="屏幕截图_20260207_145235" src="https://github.com/user-attachments/assets/eee4737b-919b-4e03-9a40-205c10934df3" />
