### PR TITLE
ci: add P0 push/PR workflow (fmt+vet+test+build+goreleaser-check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,147 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: "1.20.x"
+
+jobs:
+  fmt-vet:
+    name: Format and Vet
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Check gofmt
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="origin/${{ github.base_ref }}"
+          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            base="${{ github.event.before }}"
+          else
+            base="$(git rev-list --max-parents=0 HEAD)"
+          fi
+
+          files="$(git diff --name-only --diff-filter=ACMRT "$base"...HEAD -- '*.go')"
+          if [ -z "$files" ]; then
+            echo "No changed Go files."
+            exit 0
+          fi
+
+          unformatted="$(gofmt -l $files)"
+          test -z "$unformatted" || {
+            echo "The following files need gofmt:"
+            echo "$unformatted"
+            exit 1
+          }
+
+      - name: Vet
+        run: go vet ./...
+
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Test with race detector
+        if: matrix.os == 'ubuntu-latest'
+        run: go test -race ./...
+
+      - name: Test
+        if: matrix.os != 'ubuntu-latest'
+        run: go test ./...
+
+  build-matrix:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+          - os: ubuntu-latest
+            goos: linux
+            goarch: arm64
+          - os: ubuntu-latest
+            goos: windows
+            goarch: amd64
+          - os: macos-latest
+            goos: darwin
+            goarch: amd64
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Build
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          mkdir -p dist
+          go build -trimpath -ldflags="-s -w -X main.Mode=release" -o dist/wx_video_download_${{ matrix.goos }}_${{ matrix.goarch }} .
+
+  goreleaser-check:
+    name: GoReleaser Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Check GoReleaser config
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: check

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -1,0 +1,9 @@
+---
+title: CI
+---
+
+# CI
+
+所有 PR 必须通过 CI，并完成 code review 后再合并。
+
+P0 CI 覆盖基础格式检查、`go vet`、Go 测试、多平台编译和 GoReleaser 配置检查。


### PR DESCRIPTION
## Summary
- add a P0 CI workflow for push and pull_request events
- run changed-file gofmt checks, go vet, Go tests, multi-platform CGO-disabled builds, and GoReleaser config checks
- document that PRs must pass CI and code review before merge

## Definition of Done
- [x] `.github/workflows/ci.yml` added with fmt-vet / test matrix / build-matrix / goreleaser-check jobs
- [x] Push and PR events trigger CI
- [x] Business code unchanged (`go.mod`, `go.sum`, `cmd/`, `internal/`, `pkg/` untouched)
- [x] CI strictness avoids failing on existing gofmt debt by checking only changed Go files
- [x] CI documentation added in `docs/development/ci.md`

## Local Verification
- [x] `GOTOOLCHAIN=go1.20.14 go test ./...`
- [x] `GOTOOLCHAIN=go1.20.14 go test -race ./...`
- [x] `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOTOOLCHAIN=go1.20.14 go build ...`
- [x] `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GOTOOLCHAIN=go1.20.14 go build ...`
- [x] `CGO_ENABLED=0 GOOS=windows GOARCH=amd64 GOTOOLCHAIN=go1.20.14 go build ...`
- [x] `CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 GOTOOLCHAIN=go1.20.14 go build ...`
- [x] `CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 GOTOOLCHAIN=go1.20.14 go build ...`
- [x] YAML parse check for `.github/workflows/ci.yml`

## Notes
- Direct push to upstream was unavailable from this environment, so this PR is opened from the `kernelai` fork.
- Existing uncommitted local files were left untouched: `docs/.vitepress/config.ts` and `docs/development/architecture.md`.
