### PR TITLE
fix: emit Feed event so WXU.onFeed callbacks are triggered

### DIFF
--- a/internal/interceptor/inject/src/eventbus.js
+++ b/internal/interceptor/inject/src/eventbus.js
@@ -260,6 +260,40 @@ var WXE = (() => {
   };
 })();
 
+// Emit Feed event when any feed-related event fires
+document.addEventListener("DOMContentLoaded", function () {
+  WXE.onPCFlowLoaded((feeds) => {
+    feeds.forEach((feed) => WXE.emit(WXE.Events.Feed, feed));
+  });
+  WXE.onRecommendFeedsLoaded((feeds) => {
+    feeds.forEach((feed) => WXE.emit(WXE.Events.Feed, feed));
+  });
+  WXE.onInteractionedFeedsLoaded((feeds) => {
+    feeds.forEach((feed) => WXE.emit(WXE.Events.Feed, feed));
+  });
+  WXE.onUserFeedsLoaded((feeds) => {
+    feeds.forEach((feed) => WXE.emit(WXE.Events.Feed, feed));
+  });
+  WXE.onLiveUserFeedsLoaded((feeds) => {
+    feeds.forEach((feed) => WXE.emit(WXE.Events.Feed, feed));
+  });
+  WXE.onFetchFeedProfile((feed) => {
+    WXE.emit(WXE.Events.Feed, feed);
+  });
+  WXE.onFetchLiveProfile((live) => {
+    WXE.emit(WXE.Events.Feed, live);
+  });
+  WXE.onGotoNextFeed((feed) => {
+    WXE.emit(WXE.Events.Feed, feed);
+  });
+  WXE.onGotoPrevFeed((feed) => {
+    WXE.emit(WXE.Events.Feed, feed);
+  });
+  WXE.onHomeFeedChanged((feed) => {
+    WXE.emit(WXE.Events.Feed, feed);
+  });
+});
+
 document.addEventListener("DOMContentLoaded", function () {
   WXE.emit(WXE.Events.DOMContentLoaded, {
     href: window.location.href,

--- a/internal/interceptor/inject/src/feed.js
+++ b/internal/interceptor/inject/src/feed.js
@@ -197,8 +197,4 @@ WXU.onDOMContentLoaded(function () {
     WXU.set_cur_video();
     WXU.set_feed(feed);
   });
-  WXE.onFeed((feed) => {
-    console.log("[feed.js]WXU.onFeed", feed);
-    WXU.set_feed(feed);
-  });
 });

--- a/internal/interceptor/inject/src/home.js
+++ b/internal/interceptor/inject/src/home.js
@@ -151,8 +151,4 @@ WXU.onDOMContentLoaded(function () {
     WXU.set_cur_video();
     WXU.set_feed(feed);
   });
-  WXE.onFeed((feed) => {
-    console.log("[main.js]WXU.onFeed", feed);
-    WXU.set_feed(feed);
-  });
 });

--- a/internal/interceptor/inject/src/utils.js
+++ b/internal/interceptor/inject/src/utils.js
@@ -1839,9 +1839,17 @@ function ChannelsWebsocketClient() {
             });
             return;
           }
-          var r = await fetchFeedProfileWith({
+          var [err, r] = await fetchFeedProfileWith({
             eid: dynamicExportId,
           });
+          if (err) {
+            resp({
+              errCode: 1011,
+              errMsg: err.message,
+              payload: null,
+            });
+            return;
+          }
           var { object } = r.data;
           resp({
             ...r,

--- a/internal/interceptor/plugin.go
+++ b/internal/interceptor/plugin.go
@@ -315,7 +315,6 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 					var feeds = result.data.object;
 					// console.log("before PCFlowLoaded", result.data);
 					WXU.emit(WXU.Events.PCFlowLoaded, feeds);
-					WXU.emit(WXU.Events.Feed, feeds);
 					return result;
 				}async`
 						js_script = jsPCFlowReg.ReplaceAllString(js_script, js_pc_flow)
@@ -328,7 +327,6 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 					var feeds = result.data.object;
 					// console.log("before RecommendFeedsLoaded", result.data);
 					WXU.emit(WXU.Events.RecommendFeedsLoaded, feeds);
-					WXU.emit(WXU.Events.Feed, feeds);
 					return result;
 				}async`
 						js_script = jsRecommendFeedsReg.ReplaceAllString(js_script, js_recommend_feeds)
@@ -341,7 +339,6 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 					var feed = result.data.object;
 					// console.log("before FeedProfileLoaded", result.data);
 					WXU.emit(WXU.Events.FeedProfileLoaded, feed);
-					WXU.emit(WXU.Events.Feed, feed);
 					return result;
 				}async`
 						js_script = jsFeedProfileReg.ReplaceAllString(js_script, js_feed_profile)
@@ -385,7 +382,6 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 						var feeds = result.data.object;
 						// console.log("before finderGetInteractionedFeedList", result, $1);
 						WXU.emit(WXU.Events.InteractionedFeedsLoaded, feeds);
-						WXU.emit(WXU.Events.Feed, feeds);
 						return result;
 					}}const`
 						js_script = jsFinderGetInteractionedFeedListReg.ReplaceAllString(js_script, js_finder_interactioned)
@@ -398,7 +394,6 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 					var feeds = result.data.object;
 					// console.log("before UserFeedsLoaded", result.data, $1);
 					WXU.emit(WXU.Events.UserFeedsLoaded, feeds);
-					WXU.emit(WXU.Events.Feed, feeds);
 					return result;
 				}async`
 						js_script = jsUserFeedsReg.ReplaceAllString(js_script, js_user_feed)
@@ -411,7 +406,6 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 						var feeds = result.data.object;
 						// console.log("before LiveUserFeedsLoaded", result.data, $1);
 						WXU.emit(WXU.Events.LiveUserFeedsLoaded, feeds);
-						WXU.emit(WXU.Events.Feed, feeds);
 						return result;
 					}async`
 						js_script = jsLiveFeedListReg.ReplaceAllString(js_script, js_live_feed_list)
@@ -424,7 +418,6 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 					var live = result.data;
 					// console.log("before LiveProfileLoaded", result.data);
 					WXU.emit(WXU.Events.LiveProfileLoaded, live);
-					WXU.emit(WXU.Events.Feed, live);
 					return result;
 				}async`
 						js_script = jsLiveInfoReg.ReplaceAllString(js_script, js_live_profile)
@@ -488,7 +481,6 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 						var feed = %[1]s.value.feeds[%[1]s.value.currentFeedIndex];
 						// console.log("before GotoNextFeed", %[1]s, feed);
 						WXU.emit(WXU.Events.GotoNextFeed, feed);
-						WXU.emit(WXU.Events.Feed, feed);
 					}`, flow_list_variable_name)
 						js_script = jsGoToNextFlowReg.ReplaceAllString(js_script, js_go_next_feed)
 					}
@@ -502,7 +494,6 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 						var feed = %[1]s.value.feeds[%[1]s.value.currentFeedIndex];
 						// console.log("before GotoPrevFeed", %[1]s, feed);
 						WXU.emit(WXU.Events.GotoPrevFeed, feed);
-						WXU.emit(WXU.Events.Feed, feed);
 					}`, flow_list_variable_name)
 						js_script = jsGoToPrevFlowReg.ReplaceAllString(js_script, js_go_prev_feed)
 					}
@@ -523,7 +514,6 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 						}
 						var feed = %[1]s.value.feeds[%[1]s.value.currentFeedIndex];
 						WXU.emit(WXU.Events.HomeFeedChanged, feed);
-						WXU.emit(WXU.Events.Feed, feed);
 					}`, local_feed_list_variable_name)
 						js_script = jsLoadLocalPlaylistReg.ReplaceAllString(js_script, js_load_local)
 					}

--- a/internal/interceptor/plugin.go
+++ b/internal/interceptor/plugin.go
@@ -315,6 +315,7 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 					var feeds = result.data.object;
 					// console.log("before PCFlowLoaded", result.data);
 					WXU.emit(WXU.Events.PCFlowLoaded, feeds);
+					WXU.emit(WXU.Events.Feed, feeds);
 					return result;
 				}async`
 						js_script = jsPCFlowReg.ReplaceAllString(js_script, js_pc_flow)
@@ -327,6 +328,7 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 					var feeds = result.data.object;
 					// console.log("before RecommendFeedsLoaded", result.data);
 					WXU.emit(WXU.Events.RecommendFeedsLoaded, feeds);
+					WXU.emit(WXU.Events.Feed, feeds);
 					return result;
 				}async`
 						js_script = jsRecommendFeedsReg.ReplaceAllString(js_script, js_recommend_feeds)
@@ -339,6 +341,7 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 					var feed = result.data.object;
 					// console.log("before FeedProfileLoaded", result.data);
 					WXU.emit(WXU.Events.FeedProfileLoaded, feed);
+					WXU.emit(WXU.Events.Feed, feed);
 					return result;
 				}async`
 						js_script = jsFeedProfileReg.ReplaceAllString(js_script, js_feed_profile)
@@ -382,6 +385,7 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 						var feeds = result.data.object;
 						// console.log("before finderGetInteractionedFeedList", result, $1);
 						WXU.emit(WXU.Events.InteractionedFeedsLoaded, feeds);
+						WXU.emit(WXU.Events.Feed, feeds);
 						return result;
 					}}const`
 						js_script = jsFinderGetInteractionedFeedListReg.ReplaceAllString(js_script, js_finder_interactioned)
@@ -394,6 +398,7 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 					var feeds = result.data.object;
 					// console.log("before UserFeedsLoaded", result.data, $1);
 					WXU.emit(WXU.Events.UserFeedsLoaded, feeds);
+					WXU.emit(WXU.Events.Feed, feeds);
 					return result;
 				}async`
 						js_script = jsUserFeedsReg.ReplaceAllString(js_script, js_user_feed)
@@ -406,6 +411,7 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 						var feeds = result.data.object;
 						// console.log("before LiveUserFeedsLoaded", result.data, $1);
 						WXU.emit(WXU.Events.LiveUserFeedsLoaded, feeds);
+						WXU.emit(WXU.Events.Feed, feeds);
 						return result;
 					}async`
 						js_script = jsLiveFeedListReg.ReplaceAllString(js_script, js_live_feed_list)
@@ -418,6 +424,7 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 					var live = result.data;
 					// console.log("before LiveProfileLoaded", result.data);
 					WXU.emit(WXU.Events.LiveProfileLoaded, live);
+					WXU.emit(WXU.Events.Feed, live);
 					return result;
 				}async`
 						js_script = jsLiveInfoReg.ReplaceAllString(js_script, js_live_profile)
@@ -481,6 +488,7 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 						var feed = %[1]s.value.feeds[%[1]s.value.currentFeedIndex];
 						// console.log("before GotoNextFeed", %[1]s, feed);
 						WXU.emit(WXU.Events.GotoNextFeed, feed);
+						WXU.emit(WXU.Events.Feed, feed);
 					}`, flow_list_variable_name)
 						js_script = jsGoToNextFlowReg.ReplaceAllString(js_script, js_go_next_feed)
 					}
@@ -494,6 +502,7 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 						var feed = %[1]s.value.feeds[%[1]s.value.currentFeedIndex];
 						// console.log("before GotoPrevFeed", %[1]s, feed);
 						WXU.emit(WXU.Events.GotoPrevFeed, feed);
+						WXU.emit(WXU.Events.Feed, feed);
 					}`, flow_list_variable_name)
 						js_script = jsGoToPrevFlowReg.ReplaceAllString(js_script, js_go_prev_feed)
 					}
@@ -514,6 +523,7 @@ func CreateChannelInterceptorPlugins(interceptor *Interceptor, files *ChannelInj
 						}
 						var feed = %[1]s.value.feeds[%[1]s.value.currentFeedIndex];
 						WXU.emit(WXU.Events.HomeFeedChanged, feed);
+						WXU.emit(WXU.Events.Feed, feed);
 					}`, local_feed_list_variable_name)
 						js_script = jsLoadLocalPlaylistReg.ReplaceAllString(js_script, js_load_local)
 					}


### PR DESCRIPTION
The Feed event was defined in ChannelsEvents but never emitted, causing WXU.onFeed() registered in global.js to never fire.

This change adds WXU.emit(WXU.Events.Feed, ...) alongside existing event emissions at all feed-related locations: home feed load, video detail, live detail, navigation (prev/next), and user feeds.

Fixes #397