### PR TITLE
fix(worker): prevent authentication bypass in token validation

### DIFF
--- a/internal/officialaccount/worker/index.js
+++ b/internal/officialaccount/worker/index.js
@@ -34,7 +34,7 @@ const TOKEN_CACHE = new Set();
 
 // Load tokens from DB to cache
 async function loadTokens(env) {
-  if (TOKEN_CACHE !== null) return;
+  if (TOKEN_CACHE.size > 0) return;
 
   try {
     // Create table if not exists (in case migration didn't run)
@@ -54,10 +54,10 @@ async function loadTokens(env) {
 
 // Token validation
 function validateToken(token) {
-  if (TOKEN_CACHE.size === 0) {
-    return true;
-  }
   if (!token) return false;
+  if (TOKEN_CACHE.size === 0) {
+    return false;
+  }
   return TOKEN_CACHE.has(token);
 }
 
@@ -564,11 +564,7 @@ async function handleAddToken(request, env) {
       .run();
 
     // Update cache
-    if (TOKEN_CACHE === null) {
-      await loadTokens(env);
-    } else {
-      TOKEN_CACHE.add(token);
-    }
+    TOKEN_CACHE.add(token);
 
     return Result.Ok({ token }, "Token added successfully");
   } catch (error) {
@@ -603,9 +599,7 @@ async function handleDeleteToken(request, env) {
       .run();
 
     // Update cache
-    if (TOKEN_CACHE !== null) {
-      TOKEN_CACHE.delete(token);
-    }
+    TOKEN_CACHE.delete(token);
 
     return Result.Ok({ token }, "Token deleted successfully");
   } catch (error) {
@@ -632,6 +626,9 @@ export default {
         },
       });
     }
+
+    // Ensure tokens are loaded from DB
+    await loadTokens(env);
 
     // Route handling
     try {


### PR DESCRIPTION
## Vulnerability Summary

**CWE-287 — Improper Authentication** in `internal/officialaccount/worker/index.js`

The Cloudflare Worker's token-based authentication is completely bypassed due to three interacting bugs. All API endpoints (including admin operations like adding/deleting tokens) are accessible without any valid token.

## Root Cause

`TOKEN_CACHE` is initialized as `new Set()` on line 34. The `loadTokens()` function (line 37) checks `if (TOKEN_CACHE !== null) return;` — but a `Set` is never `null`, so this condition is always true. Tokens are never loaded from the database into the cache.

Because the cache is always empty, `validateToken()` (line 56) hits the `TOKEN_CACHE.size === 0` branch and returns `true` unconditionally — allowing any request through, with or without a token.

Additionally, `loadTokens()` is never called in the main request handler (`fetch`), so even if the cache check were fixed, tokens would still not be loaded on incoming requests.

## Data Flow

1. Request arrives at the `fetch` handler (line 614)
2. `loadTokens(env)` is **never called** — tokens stay unloaded
3. Route handler calls `validateToken(token)` (e.g., lines 197, 251, 383, 487)
4. `TOKEN_CACHE.size === 0` → returns `true` → request is authorized

## Fix Description

Three changes, all in `index.js`:

1. **`loadTokens()`**: Changed the guard from `TOKEN_CACHE !== null` to `TOKEN_CACHE.size > 0`. The cache is now only skipped if tokens have already been loaded.

2. **`validateToken()`**: When `TOKEN_CACHE.size === 0` (no tokens configured), the function now returns `false` instead of `true`. A missing token (`!token`) check is also moved before the size check for clarity.

3. **`fetch` handler**: Added `await loadTokens(env)` before route handling, ensuring tokens are loaded from the database on each cold start.

Secondary cleanups in `handleAddToken` and `handleDeleteToken` remove dead branches that checked `TOKEN_CACHE === null` (impossible for a Set).

## Proof of Concept

Against an unpatched deployment, every authenticated endpoint is accessible without a token:

```bash
# List official accounts — should require auth, returns data without any token
curl https://<worker-host>/api/mp/list

# List messages — same bypass
curl https://<worker-host>/api/mp/msg/list?mp_id=1

# Admin: add a token — should be privileged, works without auth
curl -X POST https://<worker-host>/admin/token/add \
  -H "Content-Type: application/json" \
  -d '{"token": "attacker-token"}'

# Admin: delete a token
curl -X POST https://<worker-host>/admin/token/delete \
  -H "Content-Type: application/json" \
  -d '{"token": "legitimate-token"}'
```

All of these succeed because `validateToken()` always returns `true`.

**To verify locally**, trace the logic statically:
```js
const TOKEN_CACHE = new Set();       // line 34
// loadTokens: if (TOKEN_CACHE !== null) return;  → always returns, never loads
// validateToken: if (TOKEN_CACHE.size === 0) return true;  → always true
```

## Testing

- Verified `loadTokens()` now correctly loads tokens when the cache is empty
- Verified `validateToken()` rejects requests when no token is provided (`!token → false`)
- Verified `validateToken()` rejects requests when the cache is empty (no tokens configured → deny-by-default)
- Verified `validateToken()` correctly validates tokens against the cache when tokens are loaded
- Verified the `handleAddToken`/`handleDeleteToken` paths correctly update the cache without dead branches

## Adversarial Review

Before submitting, we attempted to disprove this finding: we considered whether the `TOKEN_CACHE !== null` check could ever evaluate to `false` for a `Set` (it cannot — `new Set()` is truthy and never `null`), whether there was an alternative authentication layer in front of this Worker (there isn't — it's a standalone Cloudflare Worker), and whether any middleware or framework-level gate existed (the `fetch` export is the bare entry point). The bypass is unconditional for any deployment that hasn't manually pre-populated the cache.