### PR TITLE
fix: handle shared_feed_profile websocket key

### DIFF
--- a/internal/interceptor/inject/src/utils.js
+++ b/internal/interceptor/inject/src/utils.js
@@ -1994,6 +1994,23 @@ function ChannelsWebsocketClient() {
         });
         return;
       }
+      if (key === "key:channels:shared_feed_profile") {
+        console.log("before sharedFeedProfile", data);
+        var [err, r, payload] = await fetchFeedProfileWith(data);
+        if (err) {
+          resp({
+            errCode: 1011,
+            errMsg: err.message,
+            payload: null,
+          });
+          return;
+        }
+        resp({
+          ...r,
+          payload,
+        });
+        return;
+      }
       if (key === "key:channels:fetch_feed_comment_list") {
         // console.log("[DOWNLOADER]key:channels:fetch_feed_comment_list");
         if (!data.oid) {


### PR DESCRIPTION
通过分享链接进入频道时，浏览器扩展会收到 key:channels:shared_feed_profile 类型的 websocket 消息，但此前没有处理逻辑，会落到末尾的「未匹配的 key」分支。

本次在 ChannelsWebsocketClient 里补上对应的 handler，复用 fetchFeedProfileWith，与 key:channels:feed_profile 行为保持一致。

修复后，可以正常url解析https://weixin.qq.com/sph/A48v1zOJKL

<img width="1279" height="952" alt="image" src="https://github.com/user-attachments/assets/f4bf388d-4759-4f92-ae7c-367b50c1e18f" />


<img width="1265" height="1025" alt="image" src="https://github.com/user-attachments/assets/16bef9dc-084f-4591-a4e4-220e74c8cfea" />
