### PR TITLE
Preserve file extensions when truncating long filenames

### DIFF
--- a/pkg/util/fs.go
+++ b/pkg/util/fs.go
@@ -134,6 +134,21 @@ func (fp *FilenameProcessor) truncateString(s string, maxBytes int) string {
 	return s
 }
 
+// 截断文件名主体，但保留扩展名。
+func (fp *FilenameProcessor) truncateFilenamePreservingExtension(filename string, maxBytes int) string {
+	if len(filename) <= maxBytes {
+		return filename
+	}
+
+	ext := filepath.Ext(filename)
+	if ext == "" || len(ext) >= maxBytes {
+		return fp.truncateString(filename, maxBytes)
+	}
+
+	name := strings.TrimSuffix(filename, ext)
+	return fp.truncateString(name, maxBytes-len(ext)) + ext
+}
+
 // 验证和清理文件名
 func (fp *FilenameProcessor) SanitizeFilename(filename string) (string, error) {
 	// fmt.Println("SanitizeFilename", filename)
@@ -142,7 +157,7 @@ func (fp *FilenameProcessor) SanitizeFilename(filename string) (string, error) {
 	}
 
 	// 检查长度
-	filename = fp.truncateString(filename, fp.maxFilenameLength)
+	filename = fp.truncateFilenamePreservingExtension(filename, fp.maxFilenameLength)
 
 	// 移除非法字符
 	filename = fp.forbiddenChars.ReplaceAllString(filename, "")

--- a/pkg/util/fs_test.go
+++ b/pkg/util/fs_test.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeFilenamePreservesExtensionWhenTruncated(t *testing.T) {
+	processor := NewFilenameProcessor("", make(map[string]int))
+	input := strings.Repeat("这是一个很长的视频标题", 20) + ".mp4"
+
+	name, err := processor.SanitizeFilename(input)
+	if err != nil {
+		t.Fatalf("sanitize long filename: %v", err)
+	}
+	if !strings.HasSuffix(name, ".mp4") {
+		t.Fatalf("long filename lost extension: %q", name)
+	}
+	if len(name) > processor.maxFilenameLength {
+		t.Fatalf("filename length = %d, want <= %d", len(name), processor.maxFilenameLength)
+	}
+}
+
+func TestSanitizeFilenameDoesNotChangeShortFilename(t *testing.T) {
+	processor := NewFilenameProcessor("", make(map[string]int))
+	const input = "普通标题.mp4"
+
+	name, err := processor.SanitizeFilename(input)
+	if err != nil {
+		t.Fatalf("sanitize short filename: %v", err)
+	}
+	if name != input {
+		t.Fatalf("short filename = %q, want %q", name, input)
+	}
+}


### PR DESCRIPTION
## What changed

Preserve the file extension when sanitizing an overlong filename, and add regression coverage for long Chinese video titles.

## Why

The API appended `.mp4`/other suffixes before truncating the complete filename to 235 bytes. For long titles, the suffix was cut off and the downloaded file could lose its extension.

## Fix

Truncate only the filename stem while reserving the extension length. Short filenames remain unchanged.

## Validation

- `go test ./pkg/util` passes
- Verified long Chinese title output remains within the limit and keeps `.mp4`