### PR TITLE
fix: set the system proxy on the primary network service on macOS

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ var root_cmd = &cobra.Command{
 }
 
 func init() {
-	root_cmd.PersistentFlags().StringVar(&device, "dev", "", "代理服务器网络设备")
+	root_cmd.PersistentFlags().StringVar(&device, "dev", "", "设置系统代理的网络服务名称，留空时自动取当前主服务")
 	root_cmd.PersistentFlags().StringVarP(&config_filepath, "config", "c", "", "配置文件路径")
 	root_cmd.PersistentFlags().StringVar(&workdir, "workdir", "", "运行时工作目录")
 	root_cmd.PersistentFlags().StringVar(&hostname, "hostname", "127.0.0.1", "代理服务器主机名")
@@ -67,6 +67,7 @@ func init() {
 
 	viper.BindPFlag("workdir", root_cmd.PersistentFlags().Lookup("workdir"))
 	viper.BindPFlag("debug.error", root_cmd.PersistentFlags().Lookup("debug"))
+	viper.BindPFlag("proxy.networkService", root_cmd.PersistentFlags().Lookup("dev"))
 	viper.BindPFlag("proxy.hostname", root_cmd.PersistentFlags().Lookup("hostname"))
 	viper.BindPFlag("proxy.port", root_cmd.PersistentFlags().Lookup("port"))
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"wx_channel/internal/services"
 	"wx_channel/pkg/certificate"
@@ -51,7 +52,9 @@ type UninstallCertificateCommandArgs struct {
 }
 
 func uninstall_certificate_command(args *UninstallCertificateCommandArgs) {
-	settings := system.ProxySettings{}
+	// Empty falls back to detecting the primary service; an explicitly configured service still
+	// has to be honoured, otherwise this clears the proxy somewhere it was never written.
+	settings := system.ProxySettings{Device: viper.GetString("proxy.networkService")}
 	if err := system.DisableProxy(settings); err != nil {
 		fmt.Printf("\nERROR: Failed to cancel proxy: %v\n", err.Error())
 		return

--- a/internal/api/handler_proxy.go
+++ b/internal/api/handler_proxy.go
@@ -316,6 +316,7 @@ func (c *APIClient) proxyConfigData() gin.H {
 		"system":                 original != nil && original.GetBool("proxy.system"),
 		"tun":                    original != nil && original.GetBool("proxy.tun"),
 		"default_interface":      getConfigString(original, "proxy.defaultInterface"),
+		"network_service":        getConfigString(original, "proxy.networkService"),
 		"skip_install_root_cert": original != nil && original.GetBool("proxy.skipInstallRootCert"),
 		"upstream_proxy":         getConfigString(original, "proxy.upstreamProxy"),
 		"tcp_relay": gin.H{
@@ -460,7 +461,10 @@ func (c *APIClient) buildCertEntry(ac services.AvailableCert) gin.H {
 
 func (c *APIClient) systemProxySettings() system.ProxySettings {
 	cfg := c.proxyConfigData()
+	device, _ := cfg["network_service"].(string)
 	return system.ProxySettings{
+		// Empty means "detect the primary network service", matching what enable_proxy does.
+		Device:   device,
 		Hostname: fmt.Sprint(cfg["hostname"]),
 		Port:     strconv.Itoa(proxyFirstPositive(proxyToIntDefault(cfg["port"], 2023), 2023)),
 	}

--- a/internal/application/privileges.go
+++ b/internal/application/privileges.go
@@ -43,6 +43,10 @@ func PrepareStartPrivileges(isStartCommand bool) (shouldExit bool, err error) {
 		// close handler finishes. The original, non-elevated process survives as
 		// a guardian and resets only the proxy address owned by this application.
 		_, _ = system.DisableProxyIfMatches(system.ProxySettings{
+			// Empty falls back to detecting the primary service, which is all a separate process
+			// can do; an explicitly configured service still has to be honoured, otherwise this
+			// clears the proxy somewhere it was never written.
+			Device:   viper.GetString("proxy.networkService"),
 			Hostname: viper.GetString("proxy.hostname"),
 			Port:     strconv.Itoa(viper.GetInt("proxy.port")),
 		})

--- a/internal/application/start.go
+++ b/internal/application/start.go
@@ -247,6 +247,19 @@ func Start(cfg *config.Config) error {
 		}
 		defer unregister_console_close()
 
+		// Resolve the target network service once, before the proxy is enabled, and pin it for
+		// the rest of the run. Start and Stop both resolve an empty device on their own, so
+		// leaving it empty would let them disagree when the primary service changes mid-run:
+		// the proxy would be cleared on the service that is primary at exit while staying
+		// enabled on the one it was written to, which breaks connectivity once that service
+		// becomes primary again.
+		proxy_service, proxy_warning := system.ProxyTargetDescription(interceptor_srv.ProxyDevice())
+		if proxy_service != "" {
+			// Empty means the platform has no per-service proxy (Windows, Linux); leave whatever
+			// was configured alone there rather than overwriting it.
+			interceptor_srv.SetProxyDevice(proxy_service)
+		}
+
 		if err := interceptor_srv.Start(); err != nil {
 			cleanup()
 			return fmt.Errorf("failed to start proxy service: %w", err)
@@ -261,7 +274,14 @@ func Start(cfg *config.Config) error {
 				color.Red(fmt.Sprintf("System proxy is not set, please forward traffic to %v via software", interceptor_srv.Addr()))
 				color.Red("Open the page to download after setting the proxy")
 			} else {
-				color.Green("System proxy has been set to the proxy service address")
+				if proxy_warning != "" {
+					color.Yellow("Warning: " + proxy_warning)
+				}
+				if proxy_service != "" {
+					color.Green(fmt.Sprintf("System proxy for network service %v has been set to the proxy service address", proxy_service))
+				} else {
+					color.Green("System proxy has been set to the proxy service address")
+				}
 				color.Green("Please open the page you want to download")
 				has_changed := false
 				expected_addr := interceptor_srv.Addr()
@@ -273,7 +293,10 @@ func Start(cfg *config.Config) error {
 						case <-ctx.Done():
 							return
 						case <-ticker.C:
-							cur, err := system.FetchCurProxy(system.ProxySettings{})
+							// Poll the same network service the proxy was written to; with an empty
+							// Device this would inspect the fallback service instead and never notice
+							// a change.
+							cur, err := system.FetchCurProxy(system.ProxySettings{Device: interceptor_srv.ProxyDevice()})
 							if err != nil || cur == nil {
 								continue
 							}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -329,6 +329,16 @@ func (c *Config) LoadConfig() error {
 		Group:       "Proxy",
 		HotReload:   true,
 	})
+	// 不支持热重载：切换网络服务需要先关闭旧服务上的系统代理，否则旧服务会残留一条
+	// 指向已停止的代理的设置，导致该服务被选为主服务时无法联网。
+	Register(ConfigField{
+		Key:         "proxy.networkService",
+		Type:        ConfigTypeString,
+		Default:     "",
+		Description: "设置系统代理时使用的网络服务名称，留空时自动取当前主服务。仅在自动检测失败时才需要指定，可用值见 networksetup -listallnetworkservices",
+		Title:       "网络服务",
+		Group:       "Proxy",
+	})
 	Register(ConfigField{
 		Key:         "proxy.skipInstallRootCert",
 		Type:        ConfigTypeBool,

--- a/internal/interceptor/config.go
+++ b/internal/interceptor/config.go
@@ -34,6 +34,7 @@ func NewInterceptorSettings(c *config.Config) *InterceptorConfig {
 		ProxySetSystem:           viper.GetBool("proxy.system"),
 		ProxyTun:                 viper.GetBool("proxy.tun"),
 		ProxyDefaultInterface:    viper.GetString("proxy.defaultInterface"),
+		ProxyDevice:              viper.GetString("proxy.networkService"),
 		ProxyServerPort:          viper.GetInt("proxy.port"),
 		ProxyServerHostname:      viper.GetString("proxy.hostname"),
 		ProxyTCPRelayEnabled:     viper.GetBool("proxy.tcpRelay.enabled"),

--- a/internal/interceptor/server.go
+++ b/internal/interceptor/server.go
@@ -98,6 +98,19 @@ func (s *InterceptorServer) ProxySetSystem() bool {
 	return s.Interceptor.Settings.ProxySetSystem
 }
 
+// ProxyDevice returns the network service name the system proxy is written to, or an empty
+// string when it should be detected automatically.
+func (s *InterceptorServer) ProxyDevice() string {
+	return s.Interceptor.Settings.ProxyDevice
+}
+
+// SetProxyDevice pins the network service used for the system proxy. Callers resolve it once
+// before starting so that enabling and disabling cannot end up on different services when the
+// primary service changes while the application runs.
+func (s *InterceptorServer) SetProxyDevice(device string) {
+	s.Interceptor.Settings.ProxyDevice = device
+}
+
 func (s *InterceptorServer) Addr() string {
 	return s.addr
 }

--- a/pkg/system/proxy.go
+++ b/pkg/system/proxy.go
@@ -14,9 +14,14 @@ type HardwarePort struct {
 	Interface string
 }
 
+// default_network_service is the fallback used when the primary network service cannot be
+// determined. Only macOS reads it: Windows writes the proxy to the registry and Linux goes
+// through gsettings, and both are global rather than per network service.
+const default_network_service = "Wi-Fi"
+
 func merge_default_settings(p ProxySettings) ProxySettings {
 	if p.Device == "" {
-		p.Device = "Wi-Fi" // Default to Wi-Fi device
+		p.Device = default_network_service
 		device, err := get_network_interfaces()
 		if err == nil {
 			p.Device = device.Port

--- a/pkg/system/proxy_darwin.go
+++ b/pkg/system/proxy_darwin.go
@@ -110,49 +110,89 @@ func read_network_proxy(device string, secure bool) (*network_proxy_info, error)
 	return info, nil
 }
 
-func get_network_interfaces() (*HardwarePort, error) {
-	// Get all hardware port information
-	cmd := exec.Command("networksetup", "-listallhardwareports")
+var service_uuid_re = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`)
+
+// scutil_field runs `scutil show <key>` and returns the value of the `<field> : <value>` line.
+func scutil_field(key string, field string) (string, error) {
+	cmd := exec.Command("scutil")
+	cmd.Stdin = strings.NewReader("show " + key + "\n")
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("执行 networksetup 命令失败: %v", err)
+		return "", fmt.Errorf("执行 scutil show %s 失败: %v", key, err)
 	}
-	// Parse hardware port information
-	var ports []HardwarePort
-	lines := strings.Split(string(output), "\n")
+	for _, line := range strings.Split(string(output), "\n") {
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if strings.TrimSpace(parts[0]) == field {
+			return strings.TrimSpace(parts[1]), nil
+		}
+	}
+	return "", nil
+}
 
-	var cur_port HardwarePort
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "Hardware Port:") {
-			if cur_port.Port != "" {
-				ports = append(ports, cur_port)
-			}
-			cur_port = HardwarePort{}
-			cur_port.Port = strings.TrimPrefix(line, "Hardware Port: ")
-		} else if strings.HasPrefix(line, "Device:") {
-			cur_port.Device = strings.TrimPrefix(line, "Device: ")
+// global_ipv4_key and global_ipv6_key hold the primary service per protocol. They are
+// independent: an IPv6-only network has no IPv4 global key at all, so both are consulted.
+const (
+	global_ipv4_key = "State:/Network/Global/IPv4"
+	global_ipv6_key = "State:/Network/Global/IPv6"
+)
+
+// get_network_interfaces returns the primary network service. Port holds the service name that
+// can be passed straight to networksetup (such as "Wi-Fi"), and Device holds the matching
+// interface name (such as "en0" or "utun4").
+//
+// This deliberately avoids looking the primary interface up in
+// `networksetup -listallhardwareports`. That list only covers physical hardware, so a VPN
+// service does not appear in it at all and a utun primary interface never matches, leaving the
+// caller on a hardcoded fallback service. Since macOS stores the proxy per network service and
+// only the primary service applies, that fallback writes the proxy somewhere that is not in
+// effect, and networksetup reports no error. The list is also keyed by hardware port name,
+// while networksetup addresses services by service name; the two coincide for physical
+// adapters on a default setup but are separate fields. Reading the primary service from the
+// configuration store avoids both problems and treats physical adapters and VPNs alike.
+func get_network_interfaces() (*HardwarePort, error) {
+	for _, global_key := range []string{global_ipv4_key, global_ipv6_key} {
+		uuid, err := scutil_field(global_key, "PrimaryService")
+		if err != nil {
+			return nil, err
 		}
+		if uuid == "" {
+			continue
+		}
+		// The value is interpolated into the next command, so validate its shape first.
+		if !service_uuid_re.MatchString(uuid) {
+			return nil, fmt.Errorf("主网络服务标识格式异常: %q", uuid)
+		}
+		name, err := scutil_field("Setup:/Network/Service/"+uuid, "UserDefinedName")
+		if err != nil {
+			return nil, err
+		}
+		if name == "" {
+			return nil, fmt.Errorf("主网络服务 %s 没有名称", uuid)
+		}
+		iface, _ := scutil_field(global_key, "PrimaryInterface")
+		return &HardwarePort{Port: name, Device: iface, Interface: iface}, nil
 	}
-	if cur_port.Port != "" {
-		ports = append(ports, cur_port)
+	return nil, fmt.Errorf("未找到主网络服务，当前可能没有活动网络")
+}
+
+// ProxyTargetDescription reports the network service the system proxy will be written to,
+// along with a warning to surface when detection had to fall back. macOS keeps proxy settings
+// per network service and only honours the primary one, so a wrong guess leaves interception
+// silently inactive with no error from networksetup.
+func ProxyTargetDescription(configured string) (service string, warning string) {
+	if configured != "" {
+		return configured, ""
 	}
-	// Get network interface information
-	cmd = exec.Command("scutil", "--nwi")
-	output, err = cmd.Output()
+	port, err := get_network_interfaces()
 	if err != nil {
-		return nil, fmt.Errorf("执行 scutil 命令失败: %v", err)
+		return default_network_service, fmt.Sprintf(
+			"could not determine the primary network service (%v), falling back to %s.\n"+
+				"If the download button never appears (common while a VPN is connected), pass --dev "+
+				"with the service name; run `networksetup -listallnetworkservices` to list them",
+			err, default_network_service)
 	}
-	// Use regex to parse interface information
-	re := regexp.MustCompile(`Network interfaces{0,1}: ([0-9a-zA-Z]{1,})`)
-	matches := re.FindStringSubmatch(string(output))
-	// Match interface information with hardware ports
-	if len(matches) >= 2 {
-		for i := range ports {
-			if ports[i].Device == matches[1] {
-				return &ports[i], nil
-			}
-		}
-	}
-	return nil, fmt.Errorf("未找到硬件端口信息")
+	return port.Port, ""
 }

--- a/pkg/system/proxy_darwin_test.go
+++ b/pkg/system/proxy_darwin_test.go
@@ -1,0 +1,111 @@
+//go:build darwin
+
+package system
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// primary_service_via_scutil resolves the primary network service independently of the code
+// under test, so the assertions below cannot pass just because the implementation agrees with
+// itself.
+func primary_service_via_scutil(t *testing.T) string {
+	t.Helper()
+	for _, key := range []string{"State:/Network/Global/IPv4", "State:/Network/Global/IPv6"} {
+		uuid := scutil_show_field(t, key, "PrimaryService")
+		if uuid == "" {
+			continue
+		}
+		if name := scutil_show_field(t, "Setup:/Network/Service/"+uuid, "UserDefinedName"); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func scutil_show_field(t *testing.T, key string, field string) string {
+	t.Helper()
+	cmd := exec.Command("scutil")
+	cmd.Stdin = strings.NewReader("show " + key + "\n")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) == 2 && strings.TrimSpace(parts[0]) == field {
+			return strings.TrimSpace(parts[1])
+		}
+	}
+	return ""
+}
+
+// This is the regression test for the bug this file exists to prevent.
+//
+// merge_default_settings decides which network service the system proxy is written to. macOS
+// stores proxy settings per service and honours only the primary one, so writing to any other
+// service silently does nothing — networksetup reports no error either way.
+//
+// The previous implementation resolved the primary interface and looked it up in
+// `networksetup -listallhardwareports`. VPN services are absent from that list, so a utun
+// primary interface never matched and the lookup fell back to a hardcoded "Wi-Fi". Asserting
+// against an independently resolved primary service makes that fallback fail the test instead
+// of passing silently.
+func TestMergeDefaultSettingsTargetsPrimaryService(t *testing.T) {
+	want := primary_service_via_scutil(t)
+	if want == "" {
+		t.Skip("no primary network service; nothing to compare against")
+	}
+	got := merge_default_settings(ProxySettings{}).Device
+	if got != want {
+		t.Errorf("merge_default_settings targets network service %q, but the primary service is %q. "+
+			"The proxy would be written to a service that is not in effect, and networksetup would not report an error.", got, want)
+	}
+}
+
+// An explicitly configured service must win over detection, otherwise --dev silently does
+// nothing.
+func TestMergeDefaultSettingsKeepsConfiguredService(t *testing.T) {
+	got := merge_default_settings(ProxySettings{Device: "Some Service"}).Device
+	if got != "Some Service" {
+		t.Errorf("Device = %q, want the configured value to be preserved", got)
+	}
+}
+
+// The resolved name is passed straight to networksetup, which addresses services by name, so
+// it has to exist in the service list.
+func TestGetNetworkInterfacesReturnsUsableServiceName(t *testing.T) {
+	port, err := get_network_interfaces()
+	if err != nil {
+		t.Skipf("cannot determine the primary network service (no active network?): %v", err)
+	}
+	if port == nil || port.Port == "" {
+		t.Fatal("no service name resolved")
+	}
+	output, err := exec.Command("networksetup", "-listallnetworkservices").Output()
+	if err != nil {
+		t.Skipf("networksetup failed: %v", err)
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		// The first line is a note, and disabled services are prefixed with "*".
+		if strings.TrimPrefix(strings.TrimSpace(line), "*") == port.Port {
+			t.Logf("primary service %q (interface %q) is a valid networksetup service name", port.Port, port.Device)
+			return
+		}
+	}
+	t.Errorf("primary service %q is missing from networksetup -listallnetworkservices. Services:\n%s", port.Port, output)
+}
+
+// ProxyTargetDescription must not invent a service name when one was configured explicitly,
+// and must not warn in that case either.
+func TestProxyTargetDescriptionPrefersConfiguredService(t *testing.T) {
+	service, warning := ProxyTargetDescription("Some Service")
+	if service != "Some Service" {
+		t.Errorf("service = %q, want the configured value", service)
+	}
+	if warning != "" {
+		t.Errorf("warning = %q, want none when the service is configured", warning)
+	}
+}

--- a/pkg/system/proxy_linux.go
+++ b/pkg/system/proxy_linux.go
@@ -100,6 +100,12 @@ func get_network_interfaces() (*HardwarePort, error) {
 	return nil, errors.New("not support")
 }
 
+// ProxyTargetDescription has nothing to report on Linux: the proxy is set through gsettings or
+// KIO and applies globally, so there is no network service to pick.
+func ProxyTargetDescription(configured string) (service string, warning string) {
+	return "", ""
+}
+
 func linux_proxy_backends() []linux_proxy_backend {
 	backends := []linux_proxy_backend{
 		{

--- a/pkg/system/proxy_windows.go
+++ b/pkg/system/proxy_windows.go
@@ -134,6 +134,12 @@ func get_network_interfaces() (*HardwarePort, error) {
 	return nil, errors.New("not support")
 }
 
+// ProxyTargetDescription has nothing to report on Windows: the proxy lives in the registry and
+// applies globally, so there is no network service to pick and no way to pick the wrong one.
+func ProxyTargetDescription(configured string) (service string, warning string) {
+	return "", ""
+}
+
 func read_reg_value(path string, name string) (string, error) {
 	cmd := exec.Command("reg", "query", path, "/v", name)
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
## What changed

On macOS, resolve the primary network service from the configuration store instead of matching the primary interface against the hardware-port list, so the system proxy is written to the service that is actually in effect.

Rebased onto current `main`.

## Why

`get_network_interfaces()` read the primary interface from `scutil --nwi`, then looked it up in `networksetup -listallhardwareports`. That list only covers physical hardware — a VPN service does not appear in it at all. So when the primary interface is a `utun*` tunnel the lookup never matches and `merge_default_settings` falls back to the hardcoded `"Wi-Fi"`.

macOS stores the proxy per network service and only the primary service applies. With a VPN active the proxy was therefore written to Wi-Fi while the VPN stayed primary, so interception silently did nothing. From the user side the download button simply never appears, with nothing in the log to explain why.

The identifier being matched was wrong as well: `networksetup` addresses services by **service name**, while that list is keyed by **hardware port name**. They coincide for physical adapters on a default setup, which is why wired and Wi-Fi connections work today, but they are separate fields and diverge for VPN services (`networksetup -listnetworkserviceorder` shows a service named `MyVPN` whose hardware port is `com.example.vpnclient`).

## Fix

Read the primary service directly:

```
scutil show State:/Network/Global/IPv4       -> PrimaryService : <UUID>
scutil show Setup:/Network/Service/<UUID>    -> UserDefinedName : <service name>
```

`UserDefinedName` is the name `networksetup` expects, so physical adapters and VPNs are handled the same way and the hardware-port lookup is gone. `State:/Network/Global/IPv6` is consulted too, since an IPv6-only network has no IPv4 global key.

Resolution now tracks live state, which creates an ordering requirement the old constant fallback did not have. `Start` and `Stop` each resolve an empty device independently, so a primary-service change mid-run would clear the proxy on one service while leaving it enabled on another — and once that service becomes primary again, the machine has a proxy pointing at a dead port. The service is therefore **resolved once before the proxy is enabled and pinned for the rest of the run**.

Supporting changes:

- **Make a fallback visible.** Startup reports which network service was modified, and warns when detection falls back, pointing at `--dev` and `networksetup -listallnetworkservices`. Behind a per-platform `ProxyTargetDescription()`; Windows and Linux return empty and keep their existing output, since their proxies are global and ignore `ProxySettings.Device`.
- **Wire up `--dev`.** It was bound to a variable that was never read, and `InterceptorConfig.ProxyDevice` was declared and consumed by `Start`/`Stop` but never assigned, so it was always `""`. Bound through viper as `proxy.networkService` — named for a service (`Wi-Fi`) rather than an interface (`en0`), which is what `networksetup` actually takes. Deliberately **not** marked `HotReload`: switching service at runtime would need to disable the proxy on the previous service first, and nothing does that today.
- **Cleanup paths honour the configured service.** The guardian in `privileges.go` and the `uninstall` command both built `ProxySettings` without a device, so with `--dev` they would clear the proxy on a service it was never written to.

Default behaviour is unchanged when `--dev` is not passed and detection succeeds.

## Validation

`go build`, `go vet ./...`, `go test ./...` clean; cross-compiled `windows/amd64` (with `with_gvisor,embed_inject`) and `linux/amd64`. `go.mod` and `go.sum` untouched.

The regression test asserts that `merge_default_settings` targets the primary service, resolving it through its own independent lookup rather than the code under test. Run against both implementations, on the same machine, in both network configurations:

| primary service | old implementation | this change |
|---|---|---|
| physical adapter (Wi-Fi) | pass | pass |
| VPN | **fail** — targets `Wi-Fi`, primary is the VPN | pass |

That is the property that matters for existing users: the two agree wherever the old code was correct, and diverge only in the case it got wrong.

Manually verified on macOS 26 arm64, with and without a VPN as the primary interface:

| scenario | result |
|---|---|
| no `--dev`, VPN primary | proxy lands on the VPN service, Wi-Fi untouched; effective proxy visible to apps; HTTPS through it returns 200 |
| no `--dev`, Wi-Fi primary | proxy lands on Wi-Fi; unrelated tunnels untouched |
| `--dev <service>` | proxy lands on the named service, others untouched; works for names containing spaces |
| `--dev <unknown service>` | `networksetup` exits non-zero, startup fails loudly and no proxy is written anywhere |
| proxy changed underneath | the "System proxy has been modified" warning fires |
| on exit, including `SIGTERM` | proxy cleared on whichever service was used, direct connection restored |

The tunnel number changed between runs (`utun4`, later `utun10`), so the lookup is not tied to a fixed interface name.

**Not verified by execution:** the mid-run primary-service change is covered by construction (one resolution, stored in settings, read by both the enable and disable paths) rather than by toggling a VPN during a run. Also unverified: IPv6-only networks, multiple network locations, older macOS, and Windows/Linux at runtime — those two rest on reading the code (neither `enable_proxy` reads `ProxySettings.Device`) plus a cross-compile. Worth a look on your setup before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)