### PR TITLE
fix(api): omit query strings from access logs

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -46,6 +48,28 @@ type APIClient struct {
 	fs_service             *services.FSService
 }
 
+func new_api_engine(output io.Writer) *gin.Engine {
+	engine := gin.New()
+	engine.Use(gin.LoggerWithConfig(gin.LoggerConfig{
+		Output: output,
+		Formatter: func(params gin.LogFormatterParams) string {
+			path := ""
+			if params.Request != nil && params.Request.URL != nil {
+				path = params.Request.URL.Path
+			}
+			return fmt.Sprintf("[GIN] %v |%3d| %13v | %15s |%-7s %q\n",
+				params.TimeStamp.Format("2006/01/02 - 15:04:05"),
+				params.StatusCode,
+				params.Latency,
+				params.ClientIP,
+				params.Method,
+				path,
+			)
+		},
+	}), gin.Recovery())
+	return engine
+}
+
 func NewAPIClient(
 	cfg *APIConfig,
 	parent_logger *zerolog.Logger,
@@ -67,7 +91,7 @@ func NewAPIClient(
 
 	api_client := &APIClient{
 		cfg:                    cfg,
-		engine:                 gin.Default(),
+		engine:                 new_api_engine(gin.DefaultWriter),
 		db:                     db,
 		logger:                 &logger,
 		static_assets:          static_assets,

--- a/internal/api/client_logging_test.go
+++ b/internal/api/client_logging_test.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestAccessLoggerOmitsQueryString(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var output bytes.Buffer
+	engine := new_api_engine(&output)
+	engine.GET("/safe", func(ctx *gin.Context) { ctx.Status(http.StatusNoContent) })
+
+	request := httptest.NewRequest(http.MethodGet, "/safe?pass_ticket=sentinel-secret", nil)
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, request)
+
+	logOutput := output.String()
+	if !strings.Contains(logOutput, `"/safe"`) {
+		t.Fatalf("access log omitted request path: %q", logOutput)
+	}
+	for _, forbidden := range []string{"pass_ticket", "sentinel-secret", "/safe?"} {
+		if strings.Contains(logOutput, forbidden) {
+			t.Fatalf("access log contains query data %q: %q", forbidden, logOutput)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Replace Gin's default access logger with an equivalent recovery-enabled logger that records the request path but never the query string.

## Why

Query parameters can contain credentials, signed media URLs, authorization tokens, or other private values. Gin's default request path field includes the raw query, so otherwise-safe handlers can still leak those values through access logs.

## What changed

- Build the API engine with `gin.New()`.
- Keep Gin's recovery middleware.
- Keep timestamp, status, latency, client IP, method and URL path in access logs.
- Exclude the complete query string for every API route.
- Add a regression test using a synthetic `pass_ticket` sentinel.

## Verification

- `go test ./internal/api -run TestAccessLoggerOmitsQueryString -count=1`
- `go test -race ./internal/api`
- `git diff --check`
- isolated smoke request confirmed that the access log contains `/api/mp/article/content` but not its query or sentinel value.

## Compatibility

The logger still installs `gin.Recovery()` and retains the operational fields needed to diagnose status, latency, client address, method and route path. The only intentionally removed field is the query string.
